### PR TITLE
Configurado para que si hay una incidencia la muestre directamente

### DIFF
--- a/lib/screens/listaCarreterasPorTipo.dart
+++ b/lib/screens/listaCarreterasPorTipo.dart
@@ -3,9 +3,11 @@ import 'package:info_carreteras_navarra/providers/incidencias_provider.dart';
 import 'package:info_carreteras_navarra/screens/listaIncidenciasPorCarretera.dart';
 import 'package:info_carreteras_navarra/screens/listview_screen.dart';
 
+import 'mapa_info_screen.dart';
+
 class ListaCarreterasPorTipo extends StatelessWidget {
   final String tipo;
-  
+
   ListaCarreterasPorTipo({@required this.tipo});
 
   @override
@@ -36,17 +38,32 @@ class ListaCarreterasPorTipo extends StatelessWidget {
 
   _listaElementos(List<String> data, context) {
     final List<Widget> lst = [];
-    data.forEach((ic) { 
+    data.forEach((ic) {
       final w = ListTile(
-        title: Text(ic, style: TextStyle(fontSize: 18),),
+        title: Text(
+          ic,
+          style: TextStyle(fontSize: 18),
+        ),
         trailing: Icon(Icons.keyboard_arrow_right),
-        onTap: () {
-            //print(lista[index]);
+        onTap: () async {
+          //print(lista[index]);
+          var incidencias =
+              await incidenciasProvider.cargarIncidenciasFiltradas(ic);
+          if (incidencias.length == 1) {
             Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (context) => ListaIncidenciasPorCarretera(carretera: ic)),);
-          },
+                    builder: (context) =>
+                        MapaInfoScreen(incidencia: incidencias[0])));
+          } else {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                  builder: (context) =>
+                      ListaIncidenciasPorCarretera(carretera: ic)),
+            );
+          }
+        },
       );
       lst.add(w);
       lst.add(Divider());

--- a/lib/screens/mapa_info_screen.dart
+++ b/lib/screens/mapa_info_screen.dart
@@ -101,6 +101,7 @@ class _MapaInfoScreenState extends State<MapaInfoScreen> {
             child: Icon(
               Icons.dangerous,
               color: Colors.red,
+              size: 40,
             ),
           ),
         ),

--- a/lib/widgets/swiper_widget.dart
+++ b/lib/widgets/swiper_widget.dart
@@ -31,9 +31,11 @@ class SwiperWidget extends StatelessWidget {
           onTap: () {
             //print(lista[index]);
             Navigator.push(
-                context,
-                MaterialPageRoute(
-                    builder: (context) => ListaCarreterasPorTipo(tipo: lista[index])),);
+              context,
+              MaterialPageRoute(
+                  builder: (context) =>
+                      ListaCarreterasPorTipo(tipo: lista[index])),
+            );
           },
           child: Column(
             children: [


### PR DESCRIPTION
Se configura para que en caso de que una carretera solo presente una incidencia, se abra directamente la información y el mapa de la misma.